### PR TITLE
Simplify publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,47 +9,56 @@ https://github.com/emberjs/guides.
 
 These instructions are for publishing a new version of the site at http://guides.emberjs.com. This section is intended for members of the Ember.js release team.
 
-### Build the guides
-
-First, in the [main guides repo](https://github.com/emberjs/guides), make a branch with the version number:
+To avoid repetitive typing, set the version number as an environmental variable:
 
 ```shell
-git checkout -b <version number>
-git push
+VERSION=<version number>
 ```
 
 For `<version number>` we use the following format `v<major version>.<minor version>.<patch>`, so
 `v1.10.0` is correct but `1.9.1` is not.
 
-Next, build a new snapshot and move it to the guides _site_ repo (this repo). This should be run from the main guides repo (not this one):
+### Build the guides
+
+In the [main guides repo](https://github.com/emberjs/guides), make a branch with the version number:
+
+```shell
+git checkout -b $VERSION
+git push
+```
+
+Next, build a new snapshot:
 
 ```shell
 middleman build
-mv ./build <path to guides site repo>/snapshots/<revision number>
 ```
 
-### Add the version to the site
+### Update the guides site repo
 
-Now, change directories into the guides site repo (this repo). Update the list of versions:
+Move the build to the guides _site_ repo (this repo):
+
+```shell
+mv guides/build guides.emberjs.com/snapshots/$VERSION
+```
+
+Now, change directories into the guides site repo. Update the list of versions:
 
 ```shell
 node tasks/update-versions
+```
+
+Publish the searchable content with the new revision:
+
+```shell
+node tasks/publish-search --engine ember-guides --environment production --revision $VERSION --api-key $API_KEY
 ```
 
 Then commit and push this repo:
 
 ```shell
 git add --all
-git commit -m "Add snapshot for Ember.js revision <revision number>"
+git commit -m "Add snapshot for Ember.js revision $VERSION"
 git push
-```
-
-### Update search
-
-Publish the searchable content with the new revision:
-
-```shell
-node tasks/publish-search --engine ember-guides --environment production --revision <revision number> --api-key <api key>
 ```
 
 ### Publish


### PR DESCRIPTION
- Put search before commit so that the version number update gets committed
- Use an env var to avoid repetitive typing
- Make reasonable assumption about directory structure for better copy-and-paste-ability
